### PR TITLE
Fix package.json: license, description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "strong-data-uri",
   "version": "1.0.0",
-  "description": "Parser for `data:` URIs",
-  "license": {
-    "name": "Dual MIT/StrongLoop",
-    "url": "https://github.com/strongloop/strong-data-uri/blob/master/LICENSE"
-  },
+  "description": "Parser and builder for `data:` URIs",
+  "license": "(MIT OR LicenseRef-LICENSE.md)",
   "main": "index.js",
   "scripts": {
     "pretest": "jshint *.js test",


### PR DESCRIPTION
- Change the license property to use the new SPDX expression format.
- Update the description to mention that we can build data URIs too.

Close #17

/to @rmg please review
/cc @hildjj
