### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "strong-data-uri",
   "version": "1.0.2",
   "description": "Parser and builder for `data:` URIs",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Artistic-2.0",
   "main": "index.js",
   "scripts": {
     "pretest": "jshint *.js test",


### PR DESCRIPTION
The `license` field in `package.json` must be a valid SPDX expression.

See:
- https://docs.npmjs.com/files/package.json#license