### PR TITLE
fix: throw on decode uri with line breaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function decode(uri) {
   //  data       := *urlchar
   //  parameter  := attribute "=" value
 
-  var m = /^data:([^;,]+)?((?:;(?:[^;,]+))*?)(;base64)?,(.*)/.exec(uri);
+  var m = /^data:([^;,]+)?((?:;(?:[^;,]+))*?)(;base64)?,(.*)$/.exec(uri);
   if (!m) {
     throw new Error('Not a valid data URI: "' + truncate(uri, 20) + '"');
   }

--- a/test/decode.js
+++ b/test/decode.js
@@ -134,4 +134,16 @@ describe('decode', function() {
     expect(function() { dataUri.decode('data:text/plain'); })
       .to.throw(/^Not a valid data URI/);
   });
+
+  it('throws when URI contains new lines', function() {
+    // otherwise decode returns the first line of content
+    // and the caller is none the wiser
+    expect(function() { dataUri.decode('data:text/plain,hello\nworld'); })
+      .to.throw(/^Not a valid data URI/);
+  });
+
+  it('throws when URI contains carriage return', function() {
+    expect(function() { dataUri.decode('data:text/plain,hello\rworld'); })
+      .to.throw(/^Not a valid data URI/);
+  });
 });


### PR DESCRIPTION
currently if `uri` has line breaks, decode returns the decoded first line and the caller gets back a broken image (or whatever the data uri is of)